### PR TITLE
Added warn extensions DOCX, PPTX and XLSX

### DIFF
--- a/warnattachment@jdede.de/defaults/preferences/prefs.js
+++ b/warnattachment@jdede.de/defaults/preferences/prefs.js
@@ -1,4 +1,4 @@
-pref("extensions.warnattachment.warn", "DOC,DOCM,PPT,PPTM,XLS,XLSM,PPS,PPSM,ZIP,RAR,7Z,HTML,HTM");
+pref("extensions.warnattachment.warn", "DOC,DOCM,DOCX,PPT,PPTM,PPTX,XLS,XLSM,XLSX,PPS,PPSM,ZIP,RAR,7Z,HTML,HTM");
 pref("extensions.warnattachment.blocked", "ADE,ADP,BAT,CHM,CMD,COM,CPL,EXE,HTA,INS,ISP,JAR,JS,JSE,LIB,LNK,MDE,MSC,MSI,MSP,MST,NSH,PIF,SCR,SCT,SHB,SYS,VB,VBE,VBS,VXD,WSC,WSF,WSH");
 
 pref("extensions.warnattachment.user_warning_msg", "");


### PR DESCRIPTION
Hello, I've added DOCX PPTX and XLSX to the warning extension list. Think these too should get a warning by default.