### PR TITLE
Use Services global variable if possible

### DIFF
--- a/warnattachment@jdede.de/content/api/AttachmentHandler/implementation.js
+++ b/warnattachment@jdede.de/content/api/AttachmentHandler/implementation.js
@@ -1,7 +1,9 @@
 // Experimental API: Allows to register a callback to the attachment opener
 
 var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 const LISTENER_NAME = "warnattachmentExperimentListener_";
 
 function log(msg){

--- a/warnattachment@jdede.de/content/api/DialogExperiment/implementation.js
+++ b/warnattachment@jdede.de/content/api/DialogExperiment/implementation.js
@@ -1,7 +1,9 @@
 // A basic UI for blocking dialogs
 //
 var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 
 
 var DialogExperiment = class extends ExtensionCommon.ExtensionAPI {

--- a/warnattachment@jdede.de/content/api/LegacyPrefMigration/implementation.js
+++ b/warnattachment@jdede.de/content/api/LegacyPrefMigration/implementation.js
@@ -1,7 +1,9 @@
 // Basic helper for preferences migration
 
 var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 
 const WARNATTACHMENT_EXTENSION_BASE_PREF_NAME = "extensions.warnattachment.";
 


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and also available in all system globals from version 104 https://bugzilla.mozilla.org/show_bug.cgi?id=1667455 , and those code doesn't have to import Services.jsm for recent versions.