### PR TITLE
Use var for Services global in experiments global to avoid redeclaration error

### DIFF
--- a/warnattachment@jdede.de/content/api/AttachmentHandler/implementation.js
+++ b/warnattachment@jdede.de/content/api/AttachmentHandler/implementation.js
@@ -1,7 +1,7 @@
 // Experimental API: Allows to register a callback to the attachment opener
 
 var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-const Services = globalThis.Services || ChromeUtils.import(
+var Services = globalThis.Services || ChromeUtils.import(
   "resource://gre/modules/Services.jsm"
 ).Services;
 const LISTENER_NAME = "warnattachmentExperimentListener_";

--- a/warnattachment@jdede.de/content/api/DialogExperiment/implementation.js
+++ b/warnattachment@jdede.de/content/api/DialogExperiment/implementation.js
@@ -1,7 +1,7 @@
 // A basic UI for blocking dialogs
 //
 var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-const Services = globalThis.Services || ChromeUtils.import(
+var Services = globalThis.Services || ChromeUtils.import(
   "resource://gre/modules/Services.jsm"
 ).Services;
 

--- a/warnattachment@jdede.de/content/api/LegacyPrefMigration/implementation.js
+++ b/warnattachment@jdede.de/content/api/LegacyPrefMigration/implementation.js
@@ -1,7 +1,7 @@
 // Basic helper for preferences migration
 
 var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-const Services = globalThis.Services || ChromeUtils.import(
+var Services = globalThis.Services || ChromeUtils.import(
   "resource://gre/modules/Services.jsm"
 ).Services;
 


### PR DESCRIPTION
Sorry, I didn't realize that experiments API shares the variables.
using `const` hit redeclaration error.

this is part of https://github.com/jdede/WarnAttachment/issues/20